### PR TITLE
Unicode escape

### DIFF
--- a/Sendgrid.java
+++ b/Sendgrid.java
@@ -553,7 +553,7 @@ public class Sendgrid {
             JSONArray tos_json = new JSONArray(this.getTos());
             headers.put("to", tos_json);
             this.setHeaders(headers);
-            params.put("x-smtpapi", this.getHeaders().toString());
+            params.put("x-smtpapi", escapeUnicode(this.getHeaders().toString()));
         } else {
             params.put("to", this.getTos().toString());
             if (this.getToNames().size() > 0) {
@@ -738,4 +738,18 @@ public class Sendgrid {
 
         return false;
     }
+    
+    private String escapeUnicode(String input) {
+        StringBuilder sb = new StringBuilder();
+        int len = input.length();
+        for (int i = 0; i < len; i++) {
+          int code = Character.codePointAt(input, i);
+          if (code > 127) {
+            sb.append(String.format("\\u%x", code));
+          } else {
+            sb.append(String.format("%c", code));
+          }
+        }
+        return sb.toString();
+      }
 }

--- a/Sendgrid.java
+++ b/Sendgrid.java
@@ -553,7 +553,7 @@ public class Sendgrid {
             JSONArray tos_json = new JSONArray(this.getTos());
             headers.put("to", tos_json);
             this.setHeaders(headers);
-            params.put("x-smtpapi", escapeUnicode(this.getHeaders().toString()));
+            params.put("x-smtpapi", _escapeUnicode(this.getHeaders().toString()));
         } else {
             params.put("to", this.getTos().toString());
             if (this.getToNames().size() > 0) {
@@ -739,7 +739,7 @@ public class Sendgrid {
         return false;
     }
     
-    private String escapeUnicode(String input) {
+    private String _escapeUnicode(String input) {
         StringBuilder sb = new StringBuilder();
         int len = input.length();
         for (int i = 0; i < len; i++) {


### PR DESCRIPTION
"x-smtpapi" parameter need unicode escaped characters.
For example, "あ" is converted to \u3042.
ASCII characters are not affected.
